### PR TITLE
Only convert -L<path> to -Wl,-rpath,<path> in compiler scripts if <path>...

### DIFF
--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -262,7 +262,7 @@ done
 
 # Include all -L's and prefix/whatever dirs in rpath
 for dir in "${libraries[@]}"; do
-    [ "$dir" != "." ] && rpaths+=("$dir")
+    [[ dir = $SPACK_INSTALL* ]] && rpaths+=("$dir")
 done
 rpaths+=("$SPACK_PREFIX/lib")
 rpaths+=("$SPACK_PREFIX/lib64")

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -52,6 +52,7 @@ SPACK_NO_PARALLEL_MAKE = 'SPACK_NO_PARALLEL_MAKE'
 SPACK_ENV_PATH         = 'SPACK_ENV_PATH'
 SPACK_DEPENDENCIES     = 'SPACK_DEPENDENCIES'
 SPACK_PREFIX           = 'SPACK_PREFIX'
+SPACK_INSTALL          = 'SPACK_INSTALL'
 SPACK_DEBUG            = 'SPACK_DEBUG'
 SPACK_SHORT_SPEC       = 'SPACK_SHORT_SPEC'
 SPACK_DEBUG_LOG_DIR    = 'SPACK_DEBUG_LOG_DIR'
@@ -124,6 +125,9 @@ def set_build_environment_variables(pkg):
 
     # Install prefix
     os.environ[SPACK_PREFIX] = pkg.prefix
+
+    # Install root prefix
+    os.environ[SPACK_INSTALL] = spack.install_path
 
     # Remove these vars from the environment during build becaus they
     # can affect how some packages find libraries.  We want to make


### PR DESCRIPTION
Only convert -L<path> to -Wl,-rpath,<path> in compiler scripts if <path> points into the spack install area

This specifically fixes problems with building gcc, as build and system directories were turning in in gcc library rpaths.