### PR TITLE
Binutils as spack package

### DIFF
--- a/var/spack/packages/binutils/package.py
+++ b/var/spack/packages/binutils/package.py
@@ -1,0 +1,17 @@
+from spack import *
+
+class Binutils(Package):
+    """GNU binutils, which contain the linker, assembler, objdump and others"""
+    homepage = "http://www.gnu.org/software/binutils/"
+    url      = "ftp://ftp.gnu.org/gnu/binutils/binutils-2.25.tar.bz2"
+
+    version('2.25', 'd9f3303f802a5b6b0bb73a335ab89d66')
+    version('2.24', 'e0f71a7b2ddab0f8612336ac81d9636b')
+    version('2.23.2', '4f8fa651e35ef262edc01d60fb45702e')
+    version('2.20.1', '2b9dc8f2b7dbd5ec5992c6e29de0b764')
+
+    def install(self, spec, prefix):
+        configure("--prefix=%s" % prefix)
+
+        make()
+        make("install")

--- a/var/spack/packages/gcc/package.py
+++ b/var/spack/packages/gcc/package.py
@@ -47,6 +47,7 @@ class Gcc(Package):
     depends_on("gmp")
     depends_on("mpc")     # when @4.5:
     depends_on("libelf")
+    depends_on("binutils")
 
     # Save these until we can do optional deps.
     #depends_on("isl")
@@ -73,6 +74,10 @@ class Gcc(Package):
                   "--with-stage1-ldflags=%s" % self.rpath_args,
                   "--with-boot-ldflags=%s"   % self.rpath_args,
                   "--enable-lto",
+                  "--with-gnu-ld",
+                  "--with-ld=%s/bin/ld" % spec['binutils'].prefix,
+                  "--with-gnu-as",
+                  "--with-as=%s/bin/as" % spec['binutils'].prefix,
                   "--with-quad")
         make()
         make("install")


### PR DESCRIPTION
Add binutils as a gcc dependency so it doesn't use the system linker/assembler.