### PR TITLE
basic IBM XL compiler support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@ Documentation
 [Full documentation](http://scalability-llnl.github.io/spack)
 for Spack is also available.
 
+Contributing to Spack
+------------------------
+
+Spack is an open source project, and we welcome contributions in the
+form of new packages, bugfixes, or even core development.  If you are
+interested in contributing to spack, the first step is to join the
+mailing list.  Click the link below and send the resulting email to
+subscribe:
+
+  * **[Subscribe](mailto:majordomo@lists.llnl.gov?subject=subscribe&body=subscribe%20spack)**
+  * **[Unsubscribe](mailto:majordomo@lists.llnl.gov?subject=unsubscribe&body=unsubscribe%20spack)**
+
 Authors
 ----------------
 Spack was written by Todd Gamblin, tgamblin@llnl.gov.

--- a/README.md
+++ b/README.md
@@ -32,17 +32,35 @@ Documentation
 [Full documentation](http://scalability-llnl.github.io/spack)
 for Spack is also available.
 
-Contributing to Spack
+Get Involved!
 ------------------------
 
-Spack is an open source project, and we welcome contributions in the
-form of new packages, bugfixes, or even core development.  If you are
-interested in contributing to spack, the first step is to join the
-mailing list.  Click the link below and send the resulting email to
-subscribe:
+Spack is an open source project.  Questions, discussion, and
+contributions are welcome. Contributions can be anything from new
+packages to bugfixes, or even new core features.
+
+### Mailing list
+
+If you are interested in contributing to spack, the first step is to
+join the mailing list.  We're currently using LLNL's old-fashioned
+mailing list software, so you'll need to click the links below and
+send the resulting email to subscribe or unsubscribe:
 
   * **[Subscribe](mailto:majordomo@lists.llnl.gov?subject=subscribe&body=subscribe%20spack)**
   * **[Unsubscribe](mailto:majordomo@lists.llnl.gov?subject=unsubscribe&body=unsubscribe%20spack)**
+
+### Contributions
+
+At the moment, contributing to Spack is relatively simple.  Just send us
+a [pull request](https://help.github.com/articles/using-pull-requests/).
+When you send your request, make ``develop`` the destination branch.
+
+Spack is using a rough approximation of the [Git
+Flow](http://nvie.com/posts/a-successful-git-branching-model/)
+branching model.  The ``develop`` branch contains the latest
+contributions, and ``master`` is always tagged and points to the
+latest stable release.
+
 
 Authors
 ----------------

--- a/bin/spack
+++ b/bin/spack
@@ -56,18 +56,18 @@ from external import argparse
 # Command parsing
 parser = argparse.ArgumentParser(
     description='Spack: the Supercomputing PACKage Manager.')
-parser.add_argument('-V', '--version', action='version',
-                    version="%s" % spack.spack_version)
-parser.add_argument('-v', '--verbose', action='store_true',
-                    help="Print additional output during builds")
 parser.add_argument('-d', '--debug', action='store_true',
                     help="Write out debug logs during compile")
 parser.add_argument('-k', '--insecure', action='store_true',
-                    help="Do not check ssl certificates when downloading archives.")
+                    help="Do not check ssl certificates when downloading.")
 parser.add_argument('-m', '--mock', action='store_true',
                     help="Use mock packages instead of real ones.")
 parser.add_argument('-p', '--profile', action='store_true',
                     help="Profile execution using cProfile.")
+parser.add_argument('-v', '--verbose', action='store_true',
+                    help="Print additional output during builds")
+parser.add_argument('-V', '--version', action='version',
+                    version="%s" % spack.spack_version)
 
 # each command module implements a parser() function, to which we pass its
 # subparser for setup.

--- a/lib/spack/docs/_themes/sphinx_rtd_theme/layout.html
+++ b/lib/spack/docs/_themes/sphinx_rtd_theme/layout.html
@@ -87,6 +87,17 @@
 
   <script src="//cdnjs.cloudflare.com/ajax/libs/modernizr/2.6.2/modernizr.min.js"></script>
 
+  <!-- Google Analytics -->
+  <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+    ga('create', 'UA-55665759-2', 'auto');
+    ga('send', 'pageview');
+  </script>
+
 </head>
 
 <body class="wy-body-for-nav">

--- a/lib/spack/docs/basic_usage.rst
+++ b/lib/spack/docs/basic_usage.rst
@@ -3,18 +3,16 @@
 Basic usage
 =====================
 
-Spack is implemented as a single command (``spack``) with many
-*subcommands*.  Only a small subset of commands is needed for typical
-usage.
+The ``spack`` command has many *subcommands*.  You'll only need a
+small subset of them for typical usage.
 
 
 Listing available packages
 ------------------------------
 
-The first thing you likely want to do with spack is to install some
-software.  Before that, you need to know what's available.  You can
-see available package names either using the :ref:`package-list`, or
-using the commands below.
+To install software with Spack, you need to know what software is
+available.  You can see a list of available package names at the
+:ref:`package-list` webpage, or using the ``spack list`` command.
 
 .. _spack-list:
 
@@ -43,36 +41,37 @@ To get more information on a particular package from `spack list`, use
 
 .. command-output:: spack info mpich
 
-Most of the information is self-explanatory.  *Safe versions* are
-versions that Spack has a checksum for, and Spack will use the
-checksum to ensure they downloaded without any errors or malicious
-attacks.  :ref:`Dependencies <sec-specs>` and :ref:`virtual
-dependencies <sec-virtual-dependencies>`, are described in more detail
-later.
+Most of the information is self-explanatory.  The *safe versions* are
+versions that Spack knows the checksum for, and it will use the
+checksum to verify that these versions download without errors or
+viruses.
+
+:ref:`Dependencies <sec-specs>` and :ref:`virtual dependencies
+<sec-virtual-dependencies>` are described in more detail later.
 
 .. _spack-versions:
 
 ``spack versions``
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-To see *more* available versions of a package, run ``spack versions``,
-for example:
+To see *more* available versions of a package, run ``spack versions``.
+For example:
 
 .. command-output:: spack versions libelf
 
-There are two sections in the output.  *Safe versions* are ones that
-have already been checksummed.  Spack goes a step further, though, and
-also shows you what versions are available out on the web---these are
-*remote versions*.  Spack gets this information by scraping it
-directly from web pages.  Depending on the package, Spack may or may
-not be able to find any remote versions.
+There are two sections in the output.  *Safe versions* are versions
+for which Spack has a checksum on file.  It can verify that these
+versions are downloaded correctly.
+
+In many cases, Spack can also show you what versions are available out
+on the web---these are *remote versions*.  Spack gets this information
+by scraping it directly from package web pages.  Depending on the
+package and how its releases are organized, Spack may or may not be
+able to find remote versions.
 
 
 Installing and uninstalling
 ------------------------------
-
-Now that you know how to list available packages and versions, you're
-ready to start installing things.
 
 .. _spack-install:
 
@@ -80,17 +79,17 @@ ready to start installing things.
 ~~~~~~~~~~~~~~~~~~~~~
 
 ``spack install`` will install any package shown by ``spack list``.
-To install the latest version of a package, along with all of its
-dependencies, simply give it a package name:
+For example, To install the latest version of the ``mpileaks``
+package, you might type this:
 
 .. code-block:: sh
 
    $ spack install mpileaks
 
-If `mpileaks` depends on other packages, Spack will install those
-first.  It then fetches the tarball for ``mpileaks``, expands it,
-verifies that it was downloaded without errors, builds it, and
-installs it in its own directory under ``$SPACK_HOME/opt``. You'll see
+If `mpileaks` depends on other packages, Spack will install the
+dependencies first.  It then fetches the ``mpileaks`` tarball, expands
+it, verifies that it was downloaded without errors, builds it, and
+installs it in its own directory under ``$SPACK_ROOT/opt``. You'll see
 a number of messages from spack, a lot of build output, and a message
 that the packages is installed:
 
@@ -139,11 +138,11 @@ an installation.  Spack is unique in that it can also configure the
 configurations of the same version of a package, one built with boost
 1.39.0, and the other version built with version 1.43.0, can coexist.
 
-This can all be done on the command line using special syntax.  Spack
-calls the descriptor used to refer to a particular package
-configuration a **spec**.  In the command lines above, both
-``mpileaks`` and ``mpileaks@3.0.4`` are specs.  Specs are described in
-detail in :ref:`sec-specs`.
+This can all be done on the command line using the *spec* syntax.
+Spack calls the descriptor used to refer to a particular package
+configuration a **spec**.  In the commands above, ``mpileaks`` and
+``mpileaks@3.0.4``.  We'll talk more about how you can use them to
+customize an installation in :ref:`sec-specs`.
 
 .. _spack-uninstall:
 

--- a/lib/spack/docs/getting_started.rst
+++ b/lib/spack/docs/getting_started.rst
@@ -12,20 +12,30 @@ Getting spack is easy.  You can clone it from the `github repository
    $ git clone https://github.com/scalability-llnl/spack.git
 
 This will create a directory called ``spack``.  We'll assume that the
-full path to this directory is in some environment called
-``SPACK_HOME``.  Add ``$SPACK_HOME/bin`` to your path and you're ready
-to go:
+full path to this directory is in the ``SPACK_ROOT`` environment
+variable.  Add ``$SPACK_ROOT/bin`` to your path and you're ready to
+go:
 
 .. code-block:: sh
 
-   $ export PATH=spack/bin:$PATH
+   $ export PATH=$SPACK_ROOT/bin:$PATH
    $ spack install libelf
 
-In general, most of your interactions with Spack will be through the
-``spack`` command.
+For a richer experience, use Spack's `shell support
+<http://scalability-llnl.github.io/spack/basic_usage.html#environment-modules>`_:
 
+.. code-block:: sh
 
-Install
+   # For bash users
+   $ . $SPACK_ROOT/share/spack/setup-env.sh
+
+   # For tcsh or csh users (note you must set SPACK_ROOT)
+   $ setenv SPACK_ROOT /path/to/spack
+   $ source $SPACK_ROOT/share/spack/setup-env.csh
+
+This automatically adds Spack to your ``PATH``.
+
+Installation
 --------------------
 
 You don't need to install Spack; it's ready to run as soon as you
@@ -39,6 +49,7 @@ functionality.  To install spack in a new directory, simply type:
 
     $ spack bootstrap /my/favorite/prefix
 
-This will install a new spack script in /my/favorite/prefix/bin, which
-you can use just like you would the regular spack script.  Each copy
-of spack installs packages into its own ``$PREFIX/opt`` directory.
+This will install a new spack script in ``/my/favorite/prefix/bin``,
+which you can use just like you would the regular spack script.  Each
+copy of spack installs packages into its own ``$PREFIX/opt``
+directory.

--- a/lib/spack/docs/index.rst
+++ b/lib/spack/docs/index.rst
@@ -18,8 +18,8 @@ configurations can coexist on the same system.
 Most importantly, Spack is *simple*.  It offers a simple *spec* syntax
 so that users can specify versions and configuration options
 concisely.  Spack is also simple for package authors: package files
-are writtin in pure Python, and specs allow package authors to write a
-single build script for many different builds of the same package.
+are writtin in pure Python, and specs allow package authors to
+maintain a single file for many different builds of the same package.
 
 See the :doc:`features` for examples and highlights.
 

--- a/lib/spack/env/cc
+++ b/lib/spack/env/cc
@@ -86,19 +86,19 @@ done
 #
 command=$(basename "$0")
 case "$command" in
-    cc|gcc|c89|c99|clang)
+    cc|gcc|c89|c99|clang|xlc)
         command="$SPACK_CC"
         language="C"
         ;;
-    c++|CC|g++|clang++)
+    c++|CC|g++|clang++|xlC)
         command="$SPACK_CXX"
         language="C++"
         ;;
-    f77)
+    f77|xlf)
         command="$SPACK_F77"
         language="Fortran 77"
         ;;
-    fc|f90|f95)
+    fc|f90|f95|xlf90)
         command="$SPACK_FC"
         language="Fortran 90"
         ;;

--- a/lib/spack/spack/build_environment.py
+++ b/lib/spack/spack/build_environment.py
@@ -68,16 +68,16 @@ class MakeExecutable(Executable):
        Note that if the SPACK_NO_PARALLEL_MAKE env var is set it overrides
        everything.
     """
-    def __init__(self, name, parallel):
+    def __init__(self, name, jobs):
         super(MakeExecutable, self).__init__(name)
-        self.parallel = parallel
+        self.jobs = jobs
 
     def __call__(self, *args, **kwargs):
-        parallel = kwargs.get('parallel', self.parallel)
+        parallel = kwargs.get('parallel', self.jobs > 1)
         disable_parallel = env_flag(SPACK_NO_PARALLEL_MAKE)
 
-        if parallel and not disable_parallel:
-            jobs = "-j%d" % multiprocessing.cpu_count()
+        if self.jobs > 1 and not disable_parallel:
+            jobs = "-j%d" % self.jobs
             args = (jobs,) + args
 
         super(MakeExecutable, self).__call__(*args, **kwargs)
@@ -163,14 +163,20 @@ def set_module_variables_for_package(pkg):
     """
     m = pkg.module
 
-    m.make  = MakeExecutable('make', pkg.parallel)
-    m.gmake = MakeExecutable('gmake', pkg.parallel)
+    # number of jobs spack will to build with.
+    jobs = multiprocessing.cpu_count()
+    if not pkg.parallel:
+        jobs = 1
+    elif pkg.make_jobs:
+        jobs = pkg.make_jobs
+    m.make_jobs = jobs
+
+    # TODO: make these build deps that can be installed if not found.
+    m.make  = MakeExecutable('make', jobs)
+    m.gmake = MakeExecutable('gmake', jobs)
 
     # easy shortcut to os.environ
     m.env = os.environ
-
-    # number of jobs spack prefers to build with.
-    m.make_jobs = multiprocessing.cpu_count()
 
     # Find the configure script in the archive path
     # Don't use which for this; we want to find it in the current dir.

--- a/lib/spack/spack/cmd/spec.py
+++ b/lib/spack/spack/cmd/spec.py
@@ -33,20 +33,27 @@ import spack.url as url
 description = "print out abstract and concrete versions of a spec."
 
 def setup_parser(subparser):
+    subparser.add_argument('-i', '--ids', action='store_true',
+                           help="show numerical ids for dependencies.")
     subparser.add_argument('specs', nargs=argparse.REMAINDER, help="specs of packages")
 
+
 def spec(parser, args):
+    kwargs = { 'ids'    : args.ids,
+               'indent' : 2,
+               'color'  : True }
+
     for spec in spack.cmd.parse_specs(args.specs):
         print "Input spec"
         print "------------------------------"
-        print spec.tree(color=True, indent=2)
+        print spec.tree(**kwargs)
 
         print "Normalized"
         print "------------------------------"
         spec.normalize()
-        print spec.tree(color=True, indent=2)
+        print spec.tree(**kwargs)
 
         print "Concretized"
         print "------------------------------"
         spec.concretize()
-        print spec.tree(color=True, indent=2)
+        print spec.tree(**kwargs)

--- a/lib/spack/spack/compilers/__init__.py
+++ b/lib/spack/spack/compilers/__init__.py
@@ -45,7 +45,7 @@ from spack.util.environment import get_path
 _imported_compilers_module = 'spack.compilers'
 _required_instance_vars = ['cc', 'cxx', 'f77', 'fc']
 
-_default_order = ['gcc', 'intel', 'pgi', 'clang']
+_default_order = ['gcc', 'intel', 'pgi', 'clang', 'xlc']
 
 def _auto_compiler_spec(function):
     def converter(cspec_like):

--- a/lib/spack/spack/compilers/xl.py
+++ b/lib/spack/spack/compilers/xl.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# Copyright (c) 2013, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Written by François Bissey, francois.bissey@canterbury.ac.nz, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://scalability-llnl.github.io/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License (as published by
+# the Free Software Foundation) version 2.1 dated February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+from spack.compiler import *
+
+class Xl(Compiler):
+    # Subclasses use possible names of C compiler
+    cc_names = ['xlc','xlc_r']
+
+    # Subclasses use possible names of C++ compiler
+    cxx_names = ['xlC','xlC_r','xlc++','xlc++_r']
+
+    # Subclasses use possible names of Fortran 77 compiler
+    f77_names = ['xlf','xlf_r']
+
+    # Subclasses use possible names of Fortran 90 compiler
+    fc_names = ['xlf90','xlf90_r','xlf95','xlf95_r','xlf2003','xlf2003_r','xlf2008','xlf2008_r']
+
+    @property
+    def cxx11_flag(self):
+        if self.version < ver('13.1'):
+            tty.die("Only xlC 13.1 and above have some c++11 support.")
+        else:
+            return "-qlanglvl=extended0x"
+
+    @classmethod
+    def default_version(self, comp):
+        """The '-qversion' is the standard option fo XL compilers.
+           Output looks like this::
+
+              IBM XL C/C++ for Linux, V11.1 (5724-X14)
+              Version: 11.01.0000.0000
+
+           or::
+
+              IBM XL Fortran for Linux, V13.1 (5724-X16)
+              Version: 13.01.0000.0000
+
+           or::
+
+              IBM XL C/C++ for AIX, V11.1 (5724-X13)
+              Version: 11.01.0000.0009
+
+           or::
+
+              IBM XL C/C++ Advanced Edition for Blue Gene/P, V9.0
+              Version: 09.00.0000.0017
+        """
+
+        return get_compiler_version(
+            comp, '-qversion',r'([0-9]?[0-9]\.[0-9])')
+
+    @classmethod
+    def fc_version(cls, fc):
+        """The fortran and C/C++ versions of the XL compiler are always two units apart.
+           By this we mean that the fortran release that goes with XL C/C++ 11.1 is 13.1.
+           Having such a difference in version number is confusing spack quite a lot.
+           Most notably if you keep the versions as is the default xl compiler will only
+           have fortran and no C/C++.
+           So we associate the Fortran compiler with the version associated to the C/C++
+           compiler.
+           One last stumble. Version numbers over 10 have at least a .1 those under 10
+           a .0. There is no xlf 9.x or under currently available. BG/P and BG/L can
+           such a compiler mix and possibly older version of AIX and linux on power.
+        """
+        fver = get_compiler_version(fc, '-qversion',r'([0-9]?[0-9]\.[0-9])')
+        cver = float(fver) - 2
+        if cver < 10 :
+          cver = cver - 0.1
+        return str(cver)
+
+
+    @classmethod
+    def f77_version(cls, f77):
+        return cls.fc_version(f77)

--- a/lib/spack/spack/package.py
+++ b/lib/spack/spack/package.py
@@ -333,6 +333,9 @@ class Package(object):
     """By default we build in parallel.  Subclasses can override this."""
     parallel = True
 
+    """# jobs to use for parallel make. If set, overrides default of ncpus."""
+    make_jobs = None
+
     """Most packages are NOT extendable.  Set to True if you want extensions."""
     extendable = False
 
@@ -781,9 +784,12 @@ class Package(object):
         """
         # whether to keep the prefix on failure.  Default is to destroy it.
         keep_prefix  = kwargs.get('keep_prefix', False)
-        keep_stage   = kwargs.get('keep_stage', False)
+        keep_stage   = kwargs.get('keep_stage',  False)
         ignore_deps  = kwargs.get('ignore_deps', False)
-        fake_install = kwargs.get('fake', False)
+        fake_install = kwargs.get('fake',        False)
+
+        # Override builtin number of make jobs.
+        self.make_jobs    = kwargs.get('make_jobs',   None)
 
         if not self.spec.concrete:
             raise ValueError("Can only install concrete packages.")

--- a/var/spack/packages/adept-utils/package.py
+++ b/var/spack/packages/adept-utils/package.py
@@ -30,7 +30,8 @@ class AdeptUtils(Package):
     homepage = "https://github.com/scalability-llnl/adept-utils"
     url      = "https://github.com/scalability-llnl/adept-utils/archive/v1.0.tar.gz"
 
-    version('1.0', '5c6cd9badce56c945ac8551e34804397')
+    version('1.0.1', '731a310717adcb004d9d195130efee7d')
+    version('1.0',   '5c6cd9badce56c945ac8551e34804397')
 
     depends_on("boost")
     depends_on("mpi")

--- a/var/spack/packages/mpich/package.py
+++ b/var/spack/packages/mpich/package.py
@@ -38,6 +38,15 @@ class Mpich(Package):
     provides('mpi@:3', when='@3:')
     provides('mpi@:1', when='@1:')
 
+
+    def setup_dependent_environment(self, module, spec, dep_spec):
+        """For dependencies, make mpicc's use spack wrapper."""
+        os.environ['MPICH_CC']  = 'cc'
+        os.environ['MPICH_CXX'] = 'c++'
+        os.environ['MPICH_F77'] = 'f77'
+        os.environ['MPICH_F90'] = 'f90'
+
+
     def install(self, spec, prefix):
         config_args = ["--prefix=" + prefix,
                        "--enable-shared"]

--- a/var/spack/packages/scotch/package.py
+++ b/var/spack/packages/scotch/package.py
@@ -10,6 +10,7 @@ class Scotch(Package):
     list_url = "http://gforge.inria.fr/frs/?group_id=248"
 
     version('6.0.3', '10b0cc0f184de2de99859eafaca83cfc')
+
     depends_on('mpi')
 
 


### PR DESCRIPTION
This branch enables the detection of various IBM XL compilers. It associates the fortran compiler to the proper version of the C/C++ compiler. The major version of the fortran compiler is always the major version of the C/C++ compiler plus 2 for a matching release. Minor versions are also tricky. It is important to associate C/C++ and fortran compiler of the same version as they share runtime components.

An installation of xlc-11.1/xlf-13.1 will all come under xl-11.1.