### PR TITLE
Use config file preferrences during concretization

### DIFF
--- a/lib/spack/spack/__init__.py
+++ b/lib/spack/spack/__init__.py
@@ -70,6 +70,14 @@ from spack.directory_layout import YamlDirectoryLayout
 install_layout = YamlDirectoryLayout(install_path)
 
 #
+# This controls how packages are sorted when trying to choose
+# the most preferred package.  More preferred packages are sorted
+# first.
+#
+from spack.preferred_packages import PreferredPackages
+pkgsort = PreferredPackages()
+
+#
 # This controls how things are concretized in spack.
 # Replace it with a subclass if you want different
 # policies.

--- a/lib/spack/spack/concretize.py
+++ b/lib/spack/spack/concretize.py
@@ -38,6 +38,7 @@ import spack.compilers
 import spack.architecture
 import spack.error
 from spack.version import *
+from functools import partial
 
 
 
@@ -49,8 +50,8 @@ class DefaultConcretizer(object):
 
     def concretize_version(self, spec):
         """If the spec is already concrete, return.  Otherwise take
-           the most recent available version, and default to the package's
-           version if there are no avaialble versions.
+           the preferred version from spackconfig, and default to the package's
+           version if there are no available versions.
 
            TODO: In many cases we probably want to look for installed
                  versions of each package and use an installed version
@@ -65,15 +66,17 @@ class DefaultConcretizer(object):
         if spec.versions.concrete:
             return
 
-        # If there are known avaialble versions, return the most recent
+        # If there are known available versions, return the most recent
         # version that satisfies the spec
         pkg = spec.package
+        cmp_versions = partial(spack.pkgsort.version_compare, spec.name)
         valid_versions = sorted(
             [v for v in pkg.versions
-             if any(v.satisfies(sv) for sv in spec.versions)])
+             if any(v.satisfies(sv) for sv in spec.versions)],
+            cmp=cmp_versions)
 
         if valid_versions:
-            spec.versions = ver([valid_versions[-1]])
+            spec.versions = ver([valid_versions[0]])
         else:
             raise NoValidVersionError(spec)
 
@@ -115,10 +118,10 @@ class DefaultConcretizer(object):
         """If the spec already has a compiler, we're done.  If not, then take
            the compiler used for the nearest ancestor with a compiler
            spec and use that.  If the ancestor's compiler is not
-           concrete, then give it a valid version.  If there is no
-           ancestor with a compiler, use the system default compiler.
+           concrete, then used the preferred compiler as specified in 
+           spackconfig.
 
-           Intuition: Use the system default if no package that depends on
+           Intuition: Use the spackconfig default if no package that depends on
            this one has a strict compiler requirement.  Otherwise, try to
            build with the compiler that will be used by libraries that
            link to this one, to maximize compatibility.
@@ -130,38 +133,42 @@ class DefaultConcretizer(object):
             spec.compiler in all_compilers):
             return
 
-        try:
-            nearest = next(p for p in spec.traverse(direction='parents')
-                           if p.compiler is not None).compiler
+        # Find the parent spec that has a compiler, or the root if none do
+        parent_spec = next(p for p in spec.traverse(direction='parents')
+                           if p.compiler is not None or not p.dependents)
+        parent_compiler = parent_spec.compiler
+        assert(parent_spec)
+        
+        # Check if the compiler is already fully specified
+        if parent_compiler in all_compilers:
+            spec.compiler = parent_compiler.copy()
+            return
+            
+        # Filter the compilers into a sorted list based on the compiler_order from spackconfig
+        compiler_list = all_compilers if not parent_compiler else spack.compilers.find(parent_compiler)
+        cmp_compilers = partial(spack.pkgsort.compiler_compare, parent_spec.name)
+        matches = sorted(compiler_list, cmp=cmp_compilers)
+        if not matches:
+            raise UnavailableCompilerVersionError(parent_compiler)
+            
+        # copy concrete version into parent_compiler
+        spec.compiler = matches[0].copy()
+        assert(spec.compiler.concrete)
 
-            if not nearest in all_compilers:
-                # Take the newest compiler that saisfies the spec
-                matches = sorted(spack.compilers.find(nearest))
-                if not matches:
-                    raise UnavailableCompilerVersionError(nearest)
 
-                # copy concrete version into nearest spec
-                nearest.versions = matches[-1].versions.copy()
-                assert(nearest.concrete)
-
-            spec.compiler = nearest.copy()
-
-        except StopIteration:
-            spec.compiler = spack.compilers.default_compiler().copy()
-
-
-    def choose_provider(self, spec, providers):
+    def choose_provider(self, package_spec, spec, providers):
         """This is invoked for virtual specs.  Given a spec with a virtual name,
            say "mpi", and a list of specs of possible providers of that spec,
            select a provider and return it.
         """
         assert(spec.virtual)
         assert(providers)
+        
+        provider_cmp = partial(spack.pkgsort.provider_compare, package_spec.name, spec.name)
+        sorted_providers = sorted(providers, cmp=provider_cmp)
+        first_key = sorted_providers[0]
 
-        index = spack.spec.index_specs(providers)
-        first_key = sorted(index.keys())[0]
-        latest_version = sorted(index[first_key])[-1]
-        return latest_version
+        return first_key
 
 
 class UnavailableCompilerVersionError(spack.error.SpackError):

--- a/lib/spack/spack/config.py
+++ b/lib/spack/spack/config.py
@@ -89,8 +89,8 @@ off the top-levels of the tree and return subtrees.
 import os
 import exceptions
 import sys
+import copy
 
-from external.ordereddict import OrderedDict
 from llnl.util.lang import memoized
 import spack.error
 
@@ -114,8 +114,7 @@ class _ConfigCategory:
 
 _ConfigCategory('compilers', 'compilers.yaml', True)
 _ConfigCategory('mirrors', 'mirrors.yaml', True)
-_ConfigCategory('view', 'views.yaml', True)
-_ConfigCategory('order', 'orders.yaml', True)
+_ConfigCategory('preferred', 'preferred.yaml', True)
 
 """Names of scopes and their corresponding configuration files."""
 config_scopes = [('site', os.path.join(spack.etc_path, 'spack')),
@@ -156,7 +155,7 @@ def _merge_dicts(d1, d2):
     """Recursively merges two configuration trees, with entries
        in d2 taking precedence over d1"""
     if not d1:
-        return d2.copy()
+        return copy.copy(d2)
     if not d2:
         return d1
 
@@ -228,6 +227,11 @@ def get_compilers_config(arch=None):
 def get_mirror_config():
     """Get the mirror configuration from config files"""
     return get_config('mirrors')
+
+
+def get_preferred_config():
+    """Get the preferred configuration from config files"""
+    return get_config('preferred')
 
 
 def get_config_scope_dirname(scope):

--- a/lib/spack/spack/preferred_packages.py
+++ b/lib/spack/spack/preferred_packages.py
@@ -112,9 +112,8 @@ class PreferredPackages(object):
         elif a_index == None and b_index != None: return 1
         elif a_index != None and b_index == a_index: return -1 * cmp(a, b)
         elif a_index != None and b_index != None and a_index != b_index: return cmp(a_index, b_index)
-        elif a < b: return 1 * reverse
-        elif b < a: return -1 * reverse
-        else: return 0
+        else: return cmp(a, b) * reverse
+
 
 
     # Given a sort order specified by the pkgname/component/second_key, return
@@ -148,7 +147,7 @@ class PreferredPackages(object):
         """Return less-than-0, 0, or greater than 0 if version a of pkgname is 
            respecively less-than, equal-to, or greater-than version b of pkgname. 
            One version is less-than another if it is preferred over the other."""
-        return self._spec_compare(pkgname, 'version', a, b, False, None)
+        return self._spec_compare(pkgname, 'version', a, b, True, None)
 
     
     def variant_compare(self, pkgname, a, b):

--- a/lib/spack/spack/preferred_packages.py
+++ b/lib/spack/spack/preferred_packages.py
@@ -1,0 +1,172 @@
+##############################################################################
+# Copyright (c) 2013, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+#
+# This file is part of Spack.
+# Written by Todd Gamblin, tgamblin@llnl.gov, All rights reserved.
+# LLNL-CODE-647188
+#
+# For details, see https://scalability-llnl.github.io/spack
+# Please also see the LICENSE file for our notice and the LGPL.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License (as published by
+# the Free Software Foundation) version 2.1 dated February 1999.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the IMPLIED WARRANTY OF
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms and
+# conditions of the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+##############################################################################
+
+import spack
+from spack.version import *
+
+class PreferredPackages(object):
+    _default_order = {'compiler' : [ 'gcc', 'intel', 'clang', 'pgi', 'xlc' ] }, #Arbitrary, but consistent
+
+    def __init__(self):
+        self.preferred = spack.config.get_preferred_config()
+        self._spec_for_pkgname_cache = {}
+
+    #Given a package name, sort component (e.g, version, compiler, ...), and
+    # a second_key (used by providers), return the list 
+    def _order_for_package(self, pkgname, component, second_key):
+        pkglist = [pkgname]
+        pkglist.append('all')
+        for pkg in pkglist:
+            if not pkg in self.preferred:
+                continue
+            orders = self.preferred[pkg]
+            if not type(orders) is dict:
+                continue
+            if not component in orders:
+                continue
+            order = orders[component]
+            if type(order) is dict:
+                if not second_key in order:
+                    continue;
+                order = order[second_key]
+            if not type(order) is str:
+                tty.die('Expected version list in preferred config, but got %s' % str(order))
+            order_list = order.split(',')
+            return [s.strip() for s in order_list]
+        return []
+            
+
+    # A generic sorting function. Given a package name and sort 
+    # component, return less-than-0, 0, or greater-than-0 if 
+    # a is respectively less-than, equal to, or greater than b.
+    def _component_compare(self, pkgname, component, a, b, reverse_natural_compare, second_key):
+        orderlist = self._order_for_package(pkgname, component, second_key)
+        a_in_list = str(a) in orderlist
+        b_in_list = str(b) in orderlist
+        if a_in_list and not b_in_list:
+            return -1
+        elif b_in_list and not a_in_list:
+            return 1
+
+        cmp_a = None
+        cmp_b = None
+        reverse = None
+        if not a_in_list and not b_in_list:
+            cmp_a = a
+            cmp_b = b
+            reverse = -1 if reverse_natural_compare else 1
+        else:
+            cmp_a = orderlist.index(str(a))
+            cmp_b = orderlist.index(str(b))
+            reverse = 1
+        
+        if cmp_a < cmp_b:
+            return -1 * reverse
+        elif cmp_a > cmp_b:
+            return 1 * reverse
+        else:
+            return 0
+
+
+    # A sorting function for specs.  Similar to component_compare, but
+    # a and b are considered to match entries in the sorting list if they
+    # satisfy the list component.  
+    def _spec_compare(self, pkgname, component, a, b, reverse_natural_compare, second_key):
+        specs = self._spec_for_pkgname(pkgname, component, second_key)
+        a_index = None
+        b_index = None
+        reverse = -1 if reverse_natural_compare else 1
+        for i, cspec in enumerate(specs):
+            if a_index == None and cspec.satisfies(a):
+                a_index = i
+                if b_index:
+                    break
+            if b_index == None and cspec.satisfies(b):
+                b_index = i
+                if a_index:
+                    break
+
+        if   a_index != None and b_index == None: return -1
+        elif a_index == None and b_index != None: return 1
+        elif a_index != None and b_index == a_index: return -1 * cmp(a, b)
+        elif a_index != None and b_index != None and a_index != b_index: return cmp(a_index, b_index)
+        elif a < b: return 1 * reverse
+        elif b < a: return -1 * reverse
+        else: return 0
+
+
+    # Given a sort order specified by the pkgname/component/second_key, return
+    # a list of CompilerSpecs, VersionLists, or Specs for that sorting list.
+    def _spec_for_pkgname(self, pkgname, component, second_key):
+        key = (pkgname, component, second_key)
+        if not key in self._spec_for_pkgname_cache:
+            pkglist = self._order_for_package(pkgname, component, second_key)
+            if not pkglist: 
+                if component in self._default_order:
+                    pkglist = self._default_order[component]
+            if component == 'compiler':
+                self._spec_for_pkgname_cache[key] = [spack.spec.CompilerSpec(s) for s in pkglist]
+            elif component == 'version':
+                self._spec_for_pkgname_cache[key] = [VersionList(s) for s in pkglist]
+            else:
+                self._spec_for_pkgname_cache[key] = [spack.spec.Spec(s) for s in pkglist]
+        return self._spec_for_pkgname_cache[key]
+
+    
+    def provider_compare(self, pkgname, provider_str, a, b):
+        """Return less-than-0, 0, or greater than 0 if a is respecively less-than, equal-to, or 
+           greater-than b. A and b are possible implementations of provider_str.
+           One provider is less-than another if it is preferred over the other.
+           For example, provider_compare('scorep', 'mpi', 'mvapich', 'openmpi') would return -1 if
+           mvapich should be preferred over openmpi for scorep."""
+        return self._spec_compare(pkgname, 'providers', a, b, False, provider_str)
+
+
+    def version_compare(self, pkgname, a, b):
+        """Return less-than-0, 0, or greater than 0 if version a of pkgname is 
+           respecively less-than, equal-to, or greater-than version b of pkgname. 
+           One version is less-than another if it is preferred over the other."""
+        return self._spec_compare(pkgname, 'version', a, b, False, None)
+
+    
+    def variant_compare(self, pkgname, a, b):
+        """Return less-than-0, 0, or greater than 0 if variant a of pkgname is 
+           respecively less-than, equal-to, or greater-than variant b of pkgname. 
+           One variant is less-than another if it is preferred over the other."""
+        return self._component_compare(pkgname, 'variant', a, b, False, None)
+
+
+    def architecture_compare(self, pkgname, a, b):
+        """Return less-than-0, 0, or greater than 0 if architecture a of pkgname is 
+           respecively less-than, equal-to, or greater-than architecture b of pkgname. 
+           One architecture is less-than another if it is preferred over the other."""
+        return self._component_compare(pkgname, 'architecture', a, b, False, None)
+
+
+    def compiler_compare(self, pkgname, a, b):
+        """Return less-than-0, 0, or greater than 0 if compiler a of pkgname is 
+           respecively less-than, equal-to, or greater-than compiler b of pkgname. 
+           One compiler is less-than another if it is preferred over the other."""
+        return self._spec_compare(pkgname, 'compiler', a, b, False, None)

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1614,6 +1614,40 @@ class Spec(object):
         return ''.join("^" + dep.format() for dep in self.sorted_deps())
 
 
+    def __cmp__(self, other):
+        #Package name sort order is not configurable, always goes alphabetical
+        if self.name != other.name:
+            return cmp(self.name, other.name)
+        
+        #Package version is second in compare order
+        pkgname = self.name
+        if self.versions != other.versions:
+            return spack.pkgsort.version_compare(pkgname,
+                         self.versions, other.versions)
+
+        #Compiler is third
+        if self.compiler != other.compiler:
+            return spack.pkgsort.compiler_compare(pkgname,
+                         self.compiler, other.compiler)
+
+        #Variants
+        if self.variants != other.variants:
+            return spack.pkgsort.variant_compare(pkgname,
+                         self.variants, other.variants)
+
+        #Architecture
+        if self.architecture != other.architecture:
+            return spack.pkgsort.architecture_compare(pkgname,
+                         self.architecture, other.architecture)
+
+        #Dependency is not configurable
+        if self.dep_hash() != other.dep_hash():
+            return -1 if self.dep_hash() < other.dep_hash() else 1
+
+        #Equal specs
+        return 0
+
+
     def __str__(self):
         return self.format() + self.dep_string()
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -784,7 +784,7 @@ class Spec(object):
 
             for spec in virtuals:
                 providers = spack.db.providers_for(spec)
-                concrete = spack.concretizer.choose_provider(spec, providers)
+                concrete = spack.concretizer.choose_provider(self, spec, providers)
                 concrete = concrete.copy()
                 spec._replace_with(concrete)
 

--- a/lib/spack/spack/spec.py
+++ b/lib/spack/spack/spec.py
@@ -1464,13 +1464,27 @@ class Spec(object):
            in the format string.  The format strings you can provide are::
 
                $_   Package name
-               $@   Version
-               $%   Compiler
-               $%@  Compiler & compiler version
-               $+   Options
-               $=   Architecture
-               $#   7-char prefix of DAG hash
+               $@   Version with '@' prefix
+               $%   Compiler with '%' prefix
+               $%@  Compiler with '%' prefix & compiler version with '@' prefix
+               $+   Options 
+               $=   Architecture with '=' prefix
+               $#   7-char prefix of DAG hash with '-' prefix
                $$   $
+
+               You can also use full-string versions, which leave off the prefixes:
+
+               ${PACKAGE}       Package name
+               ${VERSION}       Version
+               ${COMPILER}      Full compiler string
+               ${COMPILERNAME}  Compiler name
+               ${COMPILERVER}   Compiler version
+               ${OPTIONS}       Options
+               ${ARCHITECTURE}  Architecture
+               ${SHA1}          Dependencies 8-char sha1 prefix
+
+               ${SPACK_ROOT}    The spack root directory
+               ${SPACK_INSTALL} The default spack install directory, ${SPACK_PREFIX}/opt
 
            Optionally you can provide a width, e.g. $20_ for a 20-wide name.
            Like printf, you can provide '-' for left justification, e.g.
@@ -1487,7 +1501,8 @@ class Spec(object):
         color    = kwargs.get('color', False)
         length = len(format_string)
         out = StringIO()
-        escape = compiler = False
+        named = escape = compiler = False
+        named_str = fmt = ''
 
         def write(s, c):
             if color:
@@ -1527,9 +1542,12 @@ class Spec(object):
                 elif c == '#':
                     out.write('-' + fmt % (self.dag_hash(7)))
                 elif c == '$':
-                    if fmt != '':
+                    if fmt != '%s':
                         raise ValueError("Can't use format width with $$.")
                     out.write('$')
+                elif c == '{':
+                    named = True
+                    named_str = ''
                 escape = False
 
             elif compiler:
@@ -1542,6 +1560,43 @@ class Spec(object):
                 else:
                     out.write(c)
                 compiler = False
+
+            elif named:
+                if not c == '}':
+                    if i == length - 1:
+                        raise ValueError("Error: unterminated ${ in format: '%s'"
+                                         % format_string)
+                    named_str += c
+                    continue;
+                if named_str == 'PACKAGE':
+                    write(fmt % self.name, '@')
+                if named_str == 'VERSION':
+                    if self.versions and self.versions != _any_version:
+                        write(fmt % str(self.versions), '@')
+                elif named_str == 'COMPILER':
+                    if self.compiler:
+                        write(fmt % self.compiler, '%')
+                elif named_str == 'COMPILERNAME':
+                    if self.compiler:
+                        write(fmt % self.compiler.name, '%')
+                elif named_str == 'COMPILERVER':
+                    if self.compiler:
+                        write(fmt % self.compiler.versions, '%')
+                elif named_str == 'OPTIONS':
+                    if self.variants:
+                        write(fmt % str(self.variants), '+')
+                elif named_str == 'ARCHITECTURE':
+                    if self.architecture:
+                        write(fmt % str(self.architecture), '=')
+                elif named_str == 'SHA1':
+                    if self.dependencies:
+                        out.write(fmt % str(self.dep_hash(8)))
+                elif named_str == 'SPACK_ROOT':
+                    out.write(fmt % spack.prefix)
+                elif named_str == 'SPACK_INSTALL':
+                    out.write(fmt % spack.install_path)
+
+                named = False
 
             elif c == '$':
                 escape = True

--- a/var/spack/mock_packages/mpich/package.py
+++ b/var/spack/mock_packages/mpich/package.py
@@ -38,6 +38,7 @@ class Mpich(Package):
     version('3.0.2', 'foobarbaz')
     version('3.0.1', 'foobarbaz')
     version('3.0', 'foobarbaz')
+    version('1.0', 'foobarbas')
 
     provides('mpi@:3', when='@3:')
     provides('mpi@:1', when='@:1')


### PR DESCRIPTION
Here's an example preferred.yaml file, which could live in spack/etc/spack/ or ~/.spack/.  Manual documentation is pending

preferred:                                                    
  gperftools:                                                 
    version: 2.3,2.4                                          
  python:                                                     
    version: 2.7,2.6                                          
  libelf:                                                     
    version: 0.8.13                                           
  all:                                                        
    compiler: xlc,gcc@:4.6,gcc@4.6.1,gcc,intel,clang,pgi      
    preferred:                                                
      mpi:mvapich,mpich,openmpi                               
                                 