### PR TITLE
fixing regular expression matches to use regular expression syntax

### DIFF
--- a/share/spack/setup-env.sh
+++ b/share/spack/setup-env.sh
@@ -64,7 +64,7 @@ function spack {
     done
 
     # h and V flags don't require further output parsing.
-    if [[ "$_sp_flags" =~ *h* || "$_sp_flags" =~ *V* ]]; then
+    if [[ (! -z "$_sp_flags") && ("$_sp_flags" =~ '.*h.*' || "$_sp_flags" =~ '.*V.*') ]]; then
         command spack $_sp_flags "$@"
         return
     fi


### PR DESCRIPTION
The globbing syntax in the env setup file is read as an invalid regex by zsh, causing everything to be passed through verbatim and breaking use/unuse etc.