### PR TITLE
new package files for python-cffi and its dependency pycparser

### DIFF
--- a/var/spack/packages/py-cffi/package.py
+++ b/var/spack/packages/py-cffi/package.py
@@ -1,0 +1,17 @@
+from spack import *
+
+class PyCffi(Package):
+    """Foreign Function Interface for Python calling C code"""
+    homepage = "http://cffi.readthedocs.org/en/latest/"
+    # base https://pypi.python.org/pypi/cffi
+    url      = "https://pypi.python.org/packages/source/c/cffi/cffi-1.1.2.tar.gz#md5="
+
+    version('1.1.2', 'ca6e6c45b45caa87aee9adc7c796eaea')
+
+    extends('python')
+    depends_on('py-setuptools')
+    depends_on('py-pycparser')
+    depends_on('libffi')
+
+    def install(self, spec, prefix):
+        python('setup.py', 'install', '--prefix=%s' % prefix)

--- a/var/spack/packages/py-pycparser/package.py
+++ b/var/spack/packages/py-pycparser/package.py
@@ -1,0 +1,15 @@
+from spack import *
+
+class PyPycparser(Package):
+    """pycparser is a complete parser of the C language, written in pure python"""
+    homepage = "https://github.com/eliben/pycparser"
+    url      = "https://pypi.python.org/packages/source/p/pycparser/pycparser-2.13.tar.gz"
+
+    version('2.13', 'e4fe1a2d341b22e25da0d22f034ef32f')
+
+    
+    extends('python')
+    depends_on('py-setuptools')
+
+    def install(self, spec, prefix):
+        python('setup.py', 'install', '--prefix=%s' % prefix)


### PR DESCRIPTION
Pycparser is being pulled in primarily as a dependency for cffi here.  Python-cffi provides an alternative to cython and ctypes that creates linkable c extension modules like cython does in "pure" python, with a call out to a C compiler where necessary.