### PR TITLE
nettle depends on gmp, without it the nettle build fails on gcc 4.9.2

### DIFF
--- a/var/spack/packages/nettle/package.py
+++ b/var/spack/packages/nettle/package.py
@@ -9,6 +9,8 @@ class Nettle(Package):
 
     version('2.7', '2caa1bd667c35db71becb93c5d89737f')
 
+    depends_on('gmp')
+
     def install(self, spec, prefix):
         configure("--prefix=%s" % prefix)
         make()


### PR DESCRIPTION
Nettle depends on gmp, compiling with the system version is unreliable.  Specifically I ran into breakage with gcc-4.9.2p.