### PR TITLE
adding package for the silver searcher

### DIFF
--- a/var/spack/packages/the_silver_searcher/package.py
+++ b/var/spack/packages/the_silver_searcher/package.py
@@ -1,0 +1,18 @@
+from spack import *
+
+class TheSilverSearcher(Package):
+    """Fast recursive grep alternative"""
+    # FIXME: add a proper url for your package's homepage here.
+    homepage = "http://geoff.greer.fm/ag/"
+    url      = "http://geoff.greer.fm/ag/releases/the_silver_searcher-0.30.0.tar.gz"
+
+    version('0.30.0', '95e2e7859fab1156c835aff7413481db')
+
+    depends_on('pcre')
+    depends_on('xz')
+
+    def install(self, spec, prefix):
+        configure("--prefix=%s" % prefix)
+
+        make()
+        make("install")

--- a/var/spack/packages/the_silver_searcher/package.py
+++ b/var/spack/packages/the_silver_searcher/package.py
@@ -2,7 +2,6 @@ from spack import *
 
 class TheSilverSearcher(Package):
     """Fast recursive grep alternative"""
-    # FIXME: add a proper url for your package's homepage here.
     homepage = "http://geoff.greer.fm/ag/"
     url      = "http://geoff.greer.fm/ag/releases/the_silver_searcher-0.30.0.tar.gz"
 


### PR DESCRIPTION
Upgraded replacement for ack which is an upgraded replacement for grep.  This is an intermediary step waiting on Go support to pull in the platinum searcher, which is an upgraded replacement for this.