### PR TITLE
fix mpfr-3.1.2 url

### DIFF
--- a/var/spack/packages/mpfr/package.py
+++ b/var/spack/packages/mpfr/package.py
@@ -28,7 +28,7 @@ class Mpfr(Package):
     """The MPFR library is a C library for multiple-precision
        floating-point computations with correct rounding."""
     homepage = "http://www.mpfr.org"
-    url      = "http://www.mpfr.org/mpfr-current/mpfr-3.1.2.tar.bz2"
+    url      = "http://www.mpfr.org/mpfr-3.1.2/mpfr-3.1.2.tar.bz2"
 
     version('3.1.2', 'ee2c3ac63bf0c2359bf08fc3ee094c19')
 


### PR DESCRIPTION
3.1.3 is out, so 3.1.2 is no longer current.