### PR TITLE
pre-alpha flux build and requisite dependencies

### DIFF
--- a/var/spack/packages/asciidoc/package.py
+++ b/var/spack/packages/asciidoc/package.py
@@ -1,0 +1,18 @@
+from spack import *
+
+class Asciidoc(Package):
+    """ A presentable text document format for writing articles, UNIX man
+    pages and other small to medium sized documents."""
+    homepage = "http://asciidoc.org"
+    url      = "http://downloads.sourceforge.net/project/asciidoc/asciidoc/8.6.9/asciidoc-8.6.9.tar.gz"
+
+    version('8.6.9', 'c59018f105be8d022714b826b0be130a')
+
+    depends_on('libxml2')
+    depends_on('libxslt')
+
+    def install(self, spec, prefix):
+        configure('--prefix=%s' % prefix)
+
+        make()
+        make("install")

--- a/var/spack/packages/czmq/package.py
+++ b/var/spack/packages/czmq/package.py
@@ -1,0 +1,19 @@
+from spack import *
+
+class Czmq(Package):
+    """ A C interface to the ZMQ library """
+    homepage = "http://czmq.zeromq.org"
+    url      = "https://github.com/zeromq/czmq/archive/v3.0.2.tar.gz"
+
+    version('3.0.2', '23e9885f7ee3ce88d99d0425f52e9be1', url='https://github.com/zeromq/czmq/archive/v3.0.2.tar.gz')
+
+    depends_on('zeromq')
+
+    def install(self, spec, prefix):
+        bash = which("bash")
+        bash("./autogen.sh")
+        configure("--prefix=%s" % prefix)
+
+        make()
+        make("install")
+

--- a/var/spack/packages/docbook-xml/package.py
+++ b/var/spack/packages/docbook-xml/package.py
@@ -1,0 +1,19 @@
+import os
+import glob
+from spack import *
+
+
+class DocbookXml(Package):
+    """Docbook DTD XML files."""
+    homepage = "http://www.oasis-open.org/docbook"
+    url = "http://www.oasis-open.org/docbook/xml/4.5/docbook-xml-4.5.zip"
+
+    version('4.5', '03083e288e87a7e829e437358da7ef9e')
+
+    def install(self, spec, prefix):
+        cp = which('cp')
+
+        install_args = ['-a', '-t', prefix]
+        install_args.extend(glob.glob('*'))
+
+        cp(*install_args)

--- a/var/spack/packages/flux/package.py
+++ b/var/spack/packages/flux/package.py
@@ -1,0 +1,36 @@
+from spack import *
+import os
+
+class Flux(Package):
+    """ A next-generation resource manager (pre-alpha) """
+
+    homepage = "https://github.com/flux-framework/flux-core"
+    url      = "https://github.com/flux-framework/flux-core"
+
+    version('master', branch='master', git='https://github.com/flux-framework/flux-core')
+
+    # Also needs autotools, but should use the system version if available
+    depends_on("zeromq@4.0.4:")
+    depends_on("czmq@2.2:")
+    depends_on("lua@5.1:5.1.99")
+    depends_on("munge")
+    depends_on("libjson-c")
+    depends_on("libxslt")
+    # TODO: This provides a catalog, hacked with environment below for now
+    depends_on("docbook-xml")
+    depends_on("asciidoc")
+    depends_on("python")
+    depends_on("py-cffi")
+
+    def install(self, spec, prefix):
+        # Bootstrap with autotools
+        bash = which('bash')
+        bash('./autogen.sh')
+
+        # Fix asciidoc dependency on xml style sheets and whatnot
+        os.environ['XML_CATALOG_FILES'] = os.path.join(spec['docbook-xml'].prefix,
+                                                       'catalog.xml')
+        # Configure, compile & install
+        configure("--prefix=" + prefix)
+        make("install", "V=1")
+

--- a/var/spack/packages/libjson-c/package.py
+++ b/var/spack/packages/libjson-c/package.py
@@ -1,0 +1,14 @@
+from spack import *
+
+class LibjsonC(Package):
+    """ A JSON implementation in C """
+    homepage = "https://github.com/json-c/json-c/wiki"
+    url      = "https://s3.amazonaws.com/json-c_releases/releases/json-c-0.11.tar.gz"
+
+    version('0.11', 'aa02367d2f7a830bf1e3376f77881e98')
+
+    def install(self, spec, prefix):
+        configure('--prefix=%s' % prefix)
+
+        make()
+        make("install")

--- a/var/spack/packages/libsodium/package.py
+++ b/var/spack/packages/libsodium/package.py
@@ -1,0 +1,19 @@
+from spack import *
+
+class Libsodium(Package):
+    """Sodium is a modern, easy-to-use software library for encryption,
+    decryption, signatures, password hashing and more."""
+    homepage = "https://download.libsodium.org/doc/"
+    url      = "https://download.libsodium.org/libsodium/releases/libsodium-1.0.3.tar.gz"
+
+    version('1.0.3', 'b3bcc98e34d3250f55ae196822307fab')
+    version('1.0.2', 'dc40eb23e293448c6fc908757738003f')
+    version('1.0.1', '9a221b49fba7281ceaaf5e278d0f4430')
+    version('1.0.0', '3093dabe4e038d09f0d150cef064b2f7')
+    version('0.7.1', 'c224fe3923d1dcfe418c65c8a7246316')
+
+    def install(self, spec, prefix):
+        configure("--prefix=%s" % prefix)
+
+        make()
+        make("install")

--- a/var/spack/packages/lua/package.py
+++ b/var/spack/packages/lua/package.py
@@ -1,0 +1,26 @@
+from spack import *
+import os
+
+class Lua(Package):
+    """ The Lua programming language interpreter and library """
+    homepage = "http://www.lua.org"
+    url      = "http://www.lua.org/ftp/lua-5.1.5.tar.gz"
+
+    version('5.3.1', '797adacada8d85761c079390ff1d9961')
+    version('5.3.0', 'a1b0a7e92d0c85bbff7a8d27bf29f8af')
+    version('5.2.4', '913fdb32207046b273fdb17aad70be13')
+    version('5.2.3', 'dc7f94ec6ff15c985d2d6ad0f1b35654')
+    version('5.2.2', 'efbb645e897eae37cad4344ce8b0a614')
+    version('5.2.1', 'ae08f641b45d737d12d30291a5e5f6e3')
+    version('5.2.0', 'f1ea831f397214bae8a265995ab1a93e')
+    version('5.1.5', '2e115fe26e435e33b0d5c022e4490567')
+    version('5.1.4', 'd0870f2de55d59c1c8419f36e8fac150')
+    version('5.1.3', 'a70a8dfaa150e047866dc01a46272599')
+
+    depends_on('ncurses')
+
+    def install(self, spec, prefix):
+        make('INSTALL_TOP=%s' % prefix,
+             'MYLDFLAGS=-L%s/lib' % spec['ncurses'].prefix,
+             'linux',
+             'install')

--- a/var/spack/packages/munge/package.py
+++ b/var/spack/packages/munge/package.py
@@ -1,0 +1,20 @@
+from spack import *
+import os
+
+class Munge(Package):
+    """ MUNGE Uid 'N' Gid Emporium """
+    homepage = "https://code.google.com/p/munge/"
+    url      = "https://github.com/dun/munge/releases/download/munge-0.5.11/munge-0.5.11.tar.bz2"
+
+    version('0.5.11', 'bd8fca8d5f4c1fcbef1816482d49ee01', url='https://github.com/dun/munge/releases/download/munge-0.5.11/munge-0.5.11.tar.bz2')
+
+    depends_on('openssl')
+    depends_on('libgcrypt')
+
+    def install(self, spec, prefix):
+        os.makedirs(os.path.join(prefix, "lib/systemd/system"))
+        configure("--prefix=%s" % prefix)
+
+        make()
+        make("install")
+

--- a/var/spack/packages/ncurses/package.py
+++ b/var/spack/packages/ncurses/package.py
@@ -21,3 +21,11 @@ class Ncurses(Package):
         make()
         make("install")
 
+        configure("--prefix=%s" % prefix,
+                  "--with-shared",
+                  "--disable-widec",
+                  "--disable-pc-files",
+                  "--without-ada")
+        make()
+        make("install")
+

--- a/var/spack/packages/zeromq/package.py
+++ b/var/spack/packages/zeromq/package.py
@@ -1,0 +1,20 @@
+from spack import *
+
+class Zeromq(Package):
+    """ The ZMQ networking/concurrency library and core API """
+    homepage = "http://zguide.zeromq.org/"
+    url      = "http://download.zeromq.org/zeromq-4.1.2.tar.gz"
+
+    version('4.1.2', '159c0c56a895472f02668e692d122685')
+    version('4.1.1', '0a4b44aa085644f25c177f79dc13f253')
+    version('4.0.7', '9b46f7e7b0704b83638ef0d461fd59ab')
+    version('4.0.6', 'd47dd09ed7ae6e7fd6f9a816d7f5fdf6')
+    version('4.0.5', '73c39f5eb01b9d7eaf74a5d899f1d03d')
+
+    depends_on("libsodium")
+
+    def install(self, spec, prefix):
+        configure("--with-libsodium","--prefix=%s" % prefix)
+
+        make()
+        make("install")


### PR DESCRIPTION
NOTE: the ncurses package now installs *BOTH* versions, wide and non-wide
character for compatibility with packages that require either one.  It may be
desirable for this to be an option in the future.