### PR TITLE
Added current version 3.2 of libffi version 3.1 has a bug 

### DIFF
--- a/var/spack/packages/libffi/package.py
+++ b/var/spack/packages/libffi/package.py
@@ -6,11 +6,12 @@ class Libffi(Package):
     to call any function specified by a call interface description at
     run time."""
     homepage = "https://sourceware.org/libffi/"
-    url      = "ftp://sourceware.org/pub/libffi/libffi-3.1.tar.gz"
-
-    version('3.1', 'f5898b29bbfd70502831a212d9249d10')
+    
+    version('3.2.1','83b89587607e3eb65c70d361f13bab43',url = "ftp://sourceware.org/pub/libffi/libffi-3.2.1.tar.gz")
+    #version('3.1', 'f5898b29bbfd70502831a212d9249d10',url = "ftp://sourceware.org/pub/libffi/libffi-3.1.tar.gz") # Has a bug $(lib64) instead of ${lib64} in libffi.pc
 
     def install(self, spec, prefix):
         configure("--prefix=%s" % prefix)
         make()
         make("install")
+


### PR DESCRIPTION
libffi 3.1 has an odd bug that has since been fixed. 
See:
http://stackoverflow.com/questions/25588520/making-glib-libtool-line-6003-cd-libdir-no-such-file-or-directory

Updated the libffi to have the more recent version of libffi.