### PR TITLE
netcdf: link to MPI

### DIFF
--- a/var/spack/packages/netcdf/netcdf-4.3.3-mpi.patch
+++ b/var/spack/packages/netcdf/netcdf-4.3.3-mpi.patch
@@ -1,0 +1,25 @@
+diff -Nur netcdf-4.3.3/CMakeLists.txt netcdf-4.3.3.mpi/CMakeLists.txt
+--- netcdf-4.3.3/CMakeLists.txt	2015-02-12 16:44:35.000000000 -0500
++++ netcdf-4.3.3.mpi/CMakeLists.txt	2015-10-14 16:44:41.176300658 -0400
+@@ -753,6 +753,7 @@
+     SET(USE_PARALLEL OFF CACHE BOOL "")
+     MESSAGE(STATUS "Cannot find HDF5 library built with parallel support. Disabling parallel build.")
+   ELSE()
++    FIND_PACKAGE(MPI REQUIRED)
+     SET(USE_PARALLEL ON CACHE BOOL "")
+     SET(STATUS_PARALLEL "ON")
+   ENDIF()
+diff -Nur netcdf-4.3.3/liblib/CMakeLists.txt netcdf-4.3.3.mpi/liblib/CMakeLists.txt
+--- netcdf-4.3.3/liblib/CMakeLists.txt	2015-02-12 16:44:35.000000000 -0500
++++ netcdf-4.3.3.mpi/liblib/CMakeLists.txt	2015-10-14 16:44:57.757793634 -0400
+@@ -71,6 +71,10 @@
+   SET(TLL_LIBS ${TLL_LIBS} ${CURL_LIBRARY})
+ ENDIF()
+ 
++IF(USE_PARALLEL)
++  SET(TLL_LIBS ${TLL_LIBS} ${MPI_C_LIBRARIES})
++ENDIF()
++
+ IF(USE_HDF4)
+   SET(TLL_LIBS ${TLL_LIBS} ${HDF4_LIBRARIES})
+ ENDIF()

--- a/var/spack/packages/netcdf/package.py
+++ b/var/spack/packages/netcdf/package.py
@@ -1,28 +1,27 @@
 from spack import *
 
 class Netcdf(Package):
-    """NetCDF is a set of software libraries and self-describing, machine-independent 
-	data formats that support the creation, access, and sharing of array-oriented 
-	scientific data."""
+    """NetCDF is a set of software libraries and self-describing, machine-independent
+        data formats that support the creation, access, and sharing of array-oriented
+        scientific data."""
 
     homepage = "http://www.unidata.ucar.edu/software/netcdf/"
     url      = "ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-4.3.3.tar.gz"
 
     version('4.3.3', '5fbd0e108a54bd82cb5702a73f56d2ae')
 
+    patch('netcdf-4.3.3-mpi.patch')
+
     # Dependencies:
-	# >HDF5
+        # >HDF5
     depends_on("hdf5")
 
-    def install(self, spec, prefix):    
-        configure(
-		"--prefix=%s" % prefix, 
-		"--disable-dap", # Disable DAP.
-		"--disable-shared", # Don't build shared libraries (use static libs).
-		"CPPFLAGS=-I%s/include" % spec['hdf5'].prefix, # Link HDF5's include dir.
-		"LDFLAGS=-L%s/lib" % spec['hdf5'].prefix) # Link HDF5's lib dir.
-		
-        make("install")
+    def install(self, spec, prefix):
+        with working_dir('spack-build', create=True):
+            cmake('..',
+                "-DCMAKE_INSTALL_PREFIX:PATH=%s" % prefix,
+                "-DENABLE_DAP:BOOL=OFF", # Disable DAP.
+                "-DBUILD_SHARED_LIBS:BOOL=OFF") # Don't build shared libraries (use static libs).
 
-	# Check the newly installed netcdf package. Currently disabled.
-	# make("check")
+            make()
+            make("install")


### PR DESCRIPTION
Newer GNU linker refuses to use transitive linking; if netcdf calls
MPI_Allreduce, it must link the providing library directly.

Also switched to CMake because I don't know autoconf well enough to know
how to put MPI stuff into it.