### PR TITLE
Added v5.2.2 for xz library

### DIFF
--- a/var/spack/packages/xz/package.py
+++ b/var/spack/packages/xz/package.py
@@ -8,9 +8,13 @@ class Xz(Package):
     homepage = "http://tukaani.org/xz/"
     url      = "http://tukaani.org/xz/xz-5.2.0.tar.bz2"
 
-    version('5.2.0', '867cc8611760240ebf3440bd6e170bb9')
-
+    version('5.2.0', '867cc8611760240ebf3440bd6e170bb9',
+            url = 'http://tukaani.org/xz/xz-5.2.0.tar.bz2')
+    version('5.2.2', 'f90c9a0c8b259aee2234c4e0d7fd70af',
+            url = 'http://tukaani.org/xz/xz-5.2.2.tar.bz2')
+   
     def install(self, spec, prefix):
         configure("--prefix=%s" % prefix)
         make()
         make("install")
+


### PR DESCRIPTION
This resolves issue 138 (https://github.com/scalability-llnl/spack/issues/138). Tested by running "./spack install xz". 