### PR TITLE
clang : updated versions + depends_on(python)

### DIFF
--- a/var/spack/packages/clang/package.py
+++ b/var/spack/packages/clang/package.py
@@ -28,11 +28,16 @@ class Clang(Package):
     """The goal of the Clang project is to create a new C, C++,
        Objective C and Objective C++ front-end for the LLVM compiler.
     """
-    homepage = "http://clang.llvm.org"
-    list_url = "http://llvm.org/releases/download.html"
+    homepage = 'http://clang.llvm.org'
+    url = 'http://llvm.org/releases/3.7.0/cfe-3.7.0.src.tar.xz'
 
-    depends_on("llvm")
-    version('3.4.2', '87945973b7c73038871c5f849a818588', url='http://llvm.org/releases/3.4.2/cfe-3.4.2.src.tar.xz')
+    depends_on('llvm@3.7.0', when='@3.7.0')
+    depends_on('llvm@3.6.2', when='@3.6.2')
+    depends_on('llvm@3.5.1', when='@3.5.1')
+
+    version('3.7.0', '8f9d27335e7331cf0a4711e952f21f01', url='http://llvm.org/releases/3.7.0/cfe-3.7.0.src.tar.xz')
+    version('3.6.2', 'ff862793682f714bb7862325b9c06e20', url='http://llvm.org/releases/3.6.2/cfe-3.6.2.src.tar.xz')
+    version('3.5.1', '93f9532f8f7e6f1d8e5c1116907051cb', url='http://llvm.org/releases/3.5.1/cfe-3.5.1.src.tar.xz')
 
     def install(self, spec, prefix):
         env['CXXFLAGS'] = self.compiler.cxx11_flag

--- a/var/spack/packages/llvm/package.py
+++ b/var/spack/packages/llvm/package.py
@@ -24,6 +24,7 @@
 ##############################################################################
 from spack import *
 
+
 class Llvm(Package):
     """The LLVM Project is a collection of modular and reusable compiler and
        toolchain technologies. Despite its name, LLVM has little to do with
@@ -31,14 +32,12 @@ class Llvm(Package):
        that can be used to build them. The name "LLVM" itself is not an acronym;
        it is the full name of the project.
     """
-    homepage = "http://llvm.org/"
-    list_url = "http://llvm.org/releases/download.html"
+    homepage = 'http://llvm.org/'
+    url = 'http://llvm.org/releases/3.7.0/llvm-3.7.0.src.tar.xz'
 
+    version('3.7.0', 'b98b9495e5655a672d6cb83e1a180f8e', url='http://llvm.org/releases/3.7.0/llvm-3.7.0.src.tar.xz')
+    version('3.6.2', '0c1ee3597d75280dee603bae9cbf5cc2', url='http://llvm.org/releases/3.6.2/llvm-3.6.2.src.tar.xz')
     version('3.5.1', '2d3d8004f38852aa679e5945b8ce0b14', url='http://llvm.org/releases/3.5.1/llvm-3.5.1.src.tar.xz')
-    version('3.4.2', 'a20669f75967440de949ac3b1bad439c', url='http://llvm.org/releases/3.4.2/llvm-3.4.2.src.tar.gz')
-    version('3.0',   'a8e5f5f1c1adebae7b4a654c376a6005', url='http://llvm.org/releases/3.0/llvm-3.0.tar.gz')
-    version('2.9',   '793138412d2af2c7c7f54615f8943771', url='http://llvm.org/releases/2.9/llvm-2.9.tgz')
-    version('2.8',   '220d361b4d17051ff4bb21c64abe05ba', url='http://llvm.org/releases/2.8/llvm-2.8.tgz')
 
     def install(self, spec, prefix):
         env['CXXFLAGS'] = self.compiler.cxx11_flag

--- a/var/spack/packages/llvm/package.py
+++ b/var/spack/packages/llvm/package.py
@@ -39,15 +39,15 @@ class Llvm(Package):
     version('3.6.2', '0c1ee3597d75280dee603bae9cbf5cc2', url='http://llvm.org/releases/3.6.2/llvm-3.6.2.src.tar.xz')
     version('3.5.1', '2d3d8004f38852aa679e5945b8ce0b14', url='http://llvm.org/releases/3.5.1/llvm-3.5.1.src.tar.xz')
 
+    depends_on('python@2.7:')
+
     def install(self, spec, prefix):
         env['CXXFLAGS'] = self.compiler.cxx11_flag
 
         with working_dir('spack-build', create=True):
             cmake('..',
                   '-DLLVM_REQUIRES_RTTI=1',
-                  '-DPYTHON_EXECUTABLE=/usr/bin/python',
-                  '-DPYTHON_INCLUDE_DIR=/usr/include/python2.6',
-                  '-DPYTHON_LIBRARY=/usr/lib64/libpython2.6.so',
+                  '-DPYTHON_EXECUTABLE=%s/bin/python' % spec['python'].prefix,
                   *std_cmake_args)
             make()
             make("install")


### PR DESCRIPTION
Changeset:
- updated versions (latest three minors are supported)
- added explicit dependency on python, removed hard-coded dependency on libraries in /usr folder
- added explicit match for llvm/clang versions 