### PR TITLE
dbus: disable systemd

### DIFF
--- a/var/spack/packages/dbus/package.py
+++ b/var/spack/packages/dbus/package.py
@@ -20,7 +20,9 @@ class Dbus(Package):
     version('1.8.2', 'd6f709bbec0a022a1847c7caec9d6068')
 
     def install(self, spec, prefix):
-        configure("--prefix=%s" % prefix)
+        configure(
+            "--prefix=%s" % prefix,
+            "--disable-systemd")
         make()
         make("install")
 


### PR DESCRIPTION
Not necessary in spack. Also forcefully installs outside of the prefix.