### PR TITLE
paraview: add package

### DIFF
--- a/var/spack/packages/paraview/package.py
+++ b/var/spack/packages/paraview/package.py
@@ -1,0 +1,72 @@
+from spack import *
+
+class Paraview(Package):
+    homepage = 'http://www.paraview.org'
+    url      = 'http://www.paraview.org/files/v4.4/ParaView-v4.4.0-source.tar.gz'
+
+    version('4.4.0', 'fa1569857dd680ebb4d7ff89c2227378', url='http://www.paraview.org/files/v4.4/ParaView-v4.4.0-source.tar.gz')
+
+    variant('python', default=False, description='Enable Python support')
+    variant('matplotlib', default=False, description='Enable Matplotlib support')
+    variant('numpy', default=False, description='Enable NumPy support')
+
+    variant('tcl', default=False, description='Enable TCL support')
+
+    variant('mpi', default=False, description='Enable MPI support')
+
+    variant('osmesa', default=False, description='Enable OSMesa support')
+    variant('qt', default=False, description='Enable Qt support')
+
+    depends_on('python', when='+python')
+    depends_on('py-numpy', when='+python+numpy')
+    depends_on('py-matplotlib', when='+python+matplotlib')
+    depends_on('tcl', when='+tcl')
+    depends_on('mpi', when='+mpi')
+    depends_on('qt', when='+qt')
+
+    depends_on('bzip2')
+    depends_on('freetype')
+    depends_on('hdf5') # drags in mpi
+    depends_on('jpeg')
+    depends_on('libpng')
+    depends_on('libtiff')
+    #depends_on('libxml2') # drags in python
+    depends_on('netcdf')
+    #depends_on('protobuf') # version mismatches?
+    #depends_on('sqlite') # external version not supported
+    depends_on('zlib')
+
+    def install(self, spec, prefix):
+        with working_dir('spack-build', create=True):
+            def feature_to_bool(feature, on='ON', off='OFF'):
+                if feature in spec:
+                    return on
+                return off
+
+            def nfeature_to_bool(feature):
+                return feature_to_bool(feature, on='OFF', off='ON')
+
+            feature_args = std_cmake_args[:]
+            feature_args.append('-DPARAVIEW_BUILD_QT_GUI:BOOL=%s' % feature_to_bool('+qt'))
+            feature_args.append('-DPARAVIEW_ENABLE_PYTHON:BOOL=%s' % feature_to_bool('+python'))
+            feature_args.append('-DPARAVIEW_USE_MPI:BOOL=%s' % feature_to_bool('+mpi'))
+            feature_args.append('-DVTK_ENABLE_TCL_WRAPPING:BOOL=%s' % feature_to_bool('+tcl'))
+            feature_args.append('-DVTK_OPENGL_HAS_OSMESA:BOOL=%s' % feature_to_bool('+osmesa'))
+            feature_args.append('-DVTK_USE_X:BOOL=%s' % nfeature_to_bool('+osmesa'))
+            feature_args.append('-DVTK_RENDERING_BACKEND:STRING=%s' % feature_to_bool('+opengl2', 'OpenGL2', 'OpenGL'))
+
+            feature_args.extend(std_cmake_args)
+
+            cmake('..',
+                '-DCMAKE_INSTALL_PREFIX:PATH=%s' % prefix,
+                '-DBUILD_TESTING:BOOL=OFF',
+                '-DVTK_USER_SYSTEM_FREETYPE:BOOL=ON',
+                '-DVTK_USER_SYSTEM_HDF5:BOOL=ON',
+                '-DVTK_USER_SYSTEM_JPEG:BOOL=ON',
+                #'-DVTK_USER_SYSTEM_LIBXML2:BOOL=ON',
+                '-DVTK_USER_SYSTEM_NETCDF:BOOL=ON',
+                '-DVTK_USER_SYSTEM_TIFF:BOOL=ON',
+                '-DVTK_USER_SYSTEM_ZLIB:BOOL=ON',
+                *feature_args)
+            make()
+            make('install')


### PR DESCRIPTION
A first attempt; builds successfully. Some dependencies have hard-coded
dependencies where they shouldn't (e.g., hdf5 -> mpi, libxml -> python),
but that's a different rabbit hole.

---
Attempts to build Qt in spack have proven difficult on Fedora 23. I think it should probably not require the whole of mesa, llvm, gtk+, and a whole host of other packages by default. Qt does work if you tell it to build the gui and have a Qt installed.