### PR TITLE
generalize one of the cases to handle many more kinds of formatting o…

### DIFF
--- a/lib/spack/spack/url.py
+++ b/lib/spack/spack/url.py
@@ -209,8 +209,8 @@ def parse_version_offset(path):
         # e.g. foobar-4.5.1
         (r'-((\d+\.)*\d+)$', stem),
 
-        # e.g. foobar-4.5.1b
-        (r'-((\d+\.)*\d+\-?([a-z]|rc|RC|tp|TP)\d*)$', stem),
+        # e.g. foobar-4.5.1b, foobar4.5RC, foobar.v4.5.1b
+        (r'[-._]?v?((\d+\.)*\d+[-._]?([a-z]|rc|RC|tp|TP?)\d*)$', stem),
 
         # e.g. foobar-4.5.0-beta1, or foobar-4.50-beta
         (r'-((\d+\.)*\d+-beta(\d+)?)$', stem),


### PR DESCRIPTION
…ptions.

There appear to be a lot of special cases here that really ought to be able to be handled by the same or a handful of similar regexs. I selected one and generalized it to permit. . .
* a leading -, . or _ or null separator between package name and version
* a leading 'v' character in version
* a trailing -, . or _ or null between version and an optional trailing qualifier string
The logic now would also *allow* foobar4.5.1- and I don't know if that is truly bad.