### PR TITLE
Fixed typo : write_lock() -> write_transaction()

### DIFF
--- a/lib/spack/spack/cmd/diy.py
+++ b/lib/spack/spack/cmd/diy.py
@@ -59,7 +59,7 @@ def diy(self, args):
         tty.die("spack diy only takes one spec.")
 
     # Take a write lock before checking for existence.
-    with spack.installed_db.write_lock():
+    with spack.installed_db.write_transaction():
         spec = specs[0]
         if not spack.db.exists(spec.name):
             tty.warn("No such package: %s" % spec.name)

--- a/lib/spack/spack/cmd/install.py
+++ b/lib/spack/spack/cmd/install.py
@@ -71,7 +71,7 @@ def install(parser, args):
     specs = spack.cmd.parse_specs(args.packages, concretize=True)
     for spec in specs:
         package = spack.db.get(spec)
-        with spack.installed_db.write_lock():
+        with spack.installed_db.write_transaction():
             package.do_install(
                 keep_prefix=args.keep_prefix,
                 keep_stage=args.keep_stage,

--- a/lib/spack/spack/cmd/uninstall.py
+++ b/lib/spack/spack/cmd/uninstall.py
@@ -53,7 +53,7 @@ def uninstall(parser, args):
     if not args.packages:
         tty.die("uninstall requires at least one package argument.")
 
-    with spack.installed_db.write_lock():
+    with spack.installed_db.write_transaction():
         specs = spack.cmd.parse_specs(args.packages)
 
         # For each spec provided, make sure it refers to only one package.


### PR DESCRIPTION
Should fix a small typo in the last merge that prevents the commands `install`, `diy` and `uninstall` to run.