### PR TITLE
Was getting system python over spack python

### DIFF
--- a/var/spack/packages/libxml2/package.py
+++ b/var/spack/packages/libxml2/package.py
@@ -14,7 +14,8 @@ class Libxml2(Package):
     depends_on('xz')
 
     def install(self, spec, prefix):
-        configure("--prefix=%s" % prefix)
+        configure("--prefix=%s" % prefix, 
+                  "--with-python=%s" % spec['python'].prefix)
 
         make()
         make("install")


### PR DESCRIPTION
Was getting this error

==> No patches needed for libxml2.
==> Building libxml2.
==> Error: Command exited with status 2:
make -j32 install

See build log for details:
  /tmp/spack-stage/spack-stage-EK_WY0/libxml2-2.9.2/spack-build.out

/mnt/gpfs0/gpfs_people/kirk/spack/var/spack/packages/libxml2/package.py:20, in install:
     16       def install(self, spec, prefix):
     17           configure("--prefix=%s" % prefix)
     18   
     19           make()
  >> 20           make("install")
==> Error: Installation process had nonzero exit code.
