### PR TITLE
Added missing $_sp_flags to spack.csh 

### DIFF
--- a/share/spack/csh/spack.csh
+++ b/share/spack/csh/spack.csh
@@ -101,7 +101,7 @@ case unload:
     breaksw
 
 default:
-    \spack $_sp_args
+    \spack $_sp_flags $_sp_args
     breaksw
 endsw
 


### PR DESCRIPTION
Now options -d -k -m -p -v get passed on to bin/spack.