### PR TITLE
Fixed -l flag for 'spack extensions'

### DIFF
--- a/lib/spack/spack/cmd/extensions.py
+++ b/lib/spack/spack/cmd/extensions.py
@@ -37,7 +37,7 @@ description = "List extensions for package."
 def setup_parser(subparser):
     format_group = subparser.add_mutually_exclusive_group()
     format_group.add_argument(
-        '-l', '--long', action='store_const', dest='mode', const='long',
+        '-l', '--long', action='store_true', dest='long',
         help='Show dependency hashes as well as versions.')
     format_group.add_argument(
         '-p', '--paths', action='store_const', dest='mode', const='paths',
@@ -95,4 +95,4 @@ def extensions(parser, args):
         tty.msg("None activated.")
         return
     tty.msg("%d currently activated:" % len(activated))
-    spack.cmd.find.display_specs(activated.values(), mode=args.mode)
+    spack.cmd.find.display_specs(activated.values(), mode=args.mode, long=args.long)


### PR DESCRIPTION
Running ```spack extensions -l python``` currently results in:
```
Traceback (most recent call last):
  File "/g/g17/herbein1/Repositories/spack/bin/spack", line 146, in <module>
    main()
  File "/g/g17/herbein1/Repositories/spack/bin/spack", line 127, in main
    return_val = command(parser, args)
  File "/g/g17/herbein1/Repositories/spack/lib/spack/spack/cmd/extensions.py", line 89, in extensions
    spack.cmd.find.display_specs(installed, mode=args.mode)
  File "/g/g17/herbein1/Repositories/spack/lib/spack/spack/cmd/find.py", line 132, in display_specs
    "Invalid mode for display_specs: %s. Must be one of (paths, deps, short)." % mode)
ValueError: Invalid mode for display_specs: long. Must be one of (paths, deps, short).
```