### PR TITLE
python: target OS X 10.6

### DIFF
--- a/var/spack/packages/python/package.py
+++ b/var/spack/packages/python/package.py
@@ -26,6 +26,7 @@ class Python(Package):
     def install(self, spec, prefix):
         # Need this to allow python build to find the Python installation.
         env['PYTHONHOME'] = prefix
+        env['MACOSX_DEPLOYMENT_TARGET'] = '10.6'
 
         # Rest of install is pretty standard.
         configure("--prefix=%s" % prefix,


### PR DESCRIPTION
Targeting anything older lacks rpath stuff which configure uses.

---
Using a more accurate version might be wanted, but this is sufficient for now.