### PR TITLE
WIP: openssl: set KERNEL_BITS to make ./config work

### DIFF
--- a/var/spack/packages/openssl/package.py
+++ b/var/spack/packages/openssl/package.py
@@ -15,6 +15,8 @@ class Openssl(Package):
     parallel = False
 
     def install(self, spec, prefix):
+        env['KERNEL_BITS'] = '64' # Only on 64-bit Mac
+
         config = Executable("./config")
         config("--prefix=%s" % prefix,
                "--openssldir=%s/etc/openssl" % prefix,


### PR DESCRIPTION
Why OpenSSL refuses to build without this (it explicitly warns about it)
is a mystery.

---
Needs to only be set on OS X and 64-bit (when `darwin-x86_64` is the target).