### PR TITLE
Had to force a patch to the OMPT support, so the hash for v0.1 has changed.

### DIFF
--- a/var/spack/packages/ompt-openmp/package.py
+++ b/var/spack/packages/ompt-openmp/package.py
@@ -5,7 +5,7 @@ class OmptOpenmp(Package):
     homepage = "https://github.com/OpenMPToolsInterface/LLVM-openmp"
     url      = "http://github.com/khuck/LLVM-openmp/archive/v0.1.tar.gz"
 
-    version('0.1', 'cc004c28b6c0d564340ed6174045b370')
+    version('0.1', '2334e6a84b52da41b27afd9831ed5370')
 
     # depends_on("foo")
 

--- a/var/spack/packages/ompt-openmp/package.py
+++ b/var/spack/packages/ompt-openmp/package.py
@@ -5,7 +5,7 @@ class OmptOpenmp(Package):
     homepage = "https://github.com/OpenMPToolsInterface/LLVM-openmp"
     url      = "http://github.com/khuck/LLVM-openmp/archive/v0.1.tar.gz"
 
-    version('0.1', '3375b5ce67a48cae107371fcd811f639')
+    version('0.1', 'cc004c28b6c0d564340ed6174045b370')
 
     # depends_on("foo")
 


### PR DESCRIPTION
There was a but in the ompt support in the runtime, so that GCC 4.8 generated code could possibly change the team and parallel region ID of an OS thread while it was between begin/end barrier events. This fix was necessary for TAU and APEX support, so the v0.1 tag was force updated to this patch in git.