### PR TITLE
Boost: mpi, python and compression for iostream variants

### DIFF
--- a/var/spack/packages/boost/package.py
+++ b/var/spack/packages/boost/package.py
@@ -43,7 +43,15 @@ class Boost(Package):
     version('1.34.1', '2d938467e8a448a2c9763e0a9f8ca7e5')
     version('1.34.0', 'ed5b9291ffad776f8757a916e1726ad0')
 
+    variant('python', default=False, description='Activate the component Boost.Python')
+    variant('mpi', default=False, description='Activate the component Boost.MPI')
+    variant('compression', default=True, description='Activate the compression Boost.iostreams')
 
+    depends_on('mpi', when='+mpi')
+    depends_on('python', when='+python')
+    depends_on('zlib', when='+compression')
+    depends_on('bzip2', when='+compression')
+    
     def url_for_version(self, version):
         """Handle Boost's weird URLs, which write the version two different ways."""
         parts = [str(p) for p in Version(version)]
@@ -52,15 +60,78 @@ class Boost(Package):
         return "http://downloads.sourceforge.net/project/boost/boost/%s/boost_%s.tar.bz2" % (
             dots, underscores)
 
+    def determine_toolset(self):
+        toolsets = {'gcc': 'gcc',
+                    'icpc': 'intel',
+                    'clang++': 'clang'}
+
+        for cc, toolset in toolsets.iteritems():
+            if(cc in self.compiler.cxx_names):
+                return toolset
+
+        # fallback to gcc if no toolset found
+        return 'gcc'
+
+    def determine_bootstrap_options(self, spec, options):
+        options.append('--with-toolset=%s' % self.determine_toolset())
+
+        without_libs = []
+        if '~mpi' in spec:
+            without_libs.append('mpi')
+        if '~python' in spec:
+            without_libs.append('python')
+        else:
+            options.append('--with-python=%s' % (spec['python'].prefix.bin + '/python'))
+
+        if without_libs:
+            options.append('--without-libraries=%s' % ','.join(without_libs))
+
+        with open('user-config.jam', 'w') as f:
+            if '+mpi' in spec:
+                f.write('using mpi : %s ;\n' % (spec['mpi'].prefix.bin + '/mpicxx'))
+            if '+python' in spec:
+                f.write('using python : %s : %s ;\n' % (spec['python'].version,
+                                                      (spec['python'].prefix.bin + '/python')))
+
+    def determine_b2_options(self, spec, options):
+        if '+debug' in spec:
+            options.append('variant=debug')
+        else:
+            options.append('variant=release')
+
+        if '~compression' in spec:
+            options.extend(['-s NO_BZIP2=1',
+                            '-s NO_ZLIB=1',
+            ])
+
+        if '+compression' in spec:
+            options.extend(['-s BZIP2_INCLUDE=%s' % spec['bzip2'].prefix.include,
+                            '-s BZIP2_LIBPATH=%s' % spec['bzip2'].prefix.lib,
+                            '-s ZLIB_INCLUDE=%s' % spec['zlib'].prefix.include,
+                            '-s ZLIB_LIBPATH=%s' % spec['zlib'].prefix.lib])
+
+        options.extend(['toolset=%s' % self.determine_toolset(),
+                       'link=static,shared',
+                       '--layout=tagged'])
 
     def install(self, spec, prefix):
+        # to make him find the user-config.jam
+        env['BOOST_BUILD_PATH'] = './'
+
         bootstrap = Executable('./bootstrap.sh')
-        bootstrap()
+
+        bootstrap_options = ['--prefix=%s' % prefix]
+        self.determine_bootstrap_options(spec, bootstrap_options)
+
+        bootstrap(*bootstrap_options)
 
         # b2 used to be called bjam, before 1.47 (sigh)
         b2name = './b2' if spec.satisfies('@1.47:') else './bjam'
 
         b2 = Executable(b2name)
-        b2('install',
-           '-j %s' % make_jobs,
-           '--prefix=%s' % prefix)
+        b2_options = ['-j %s' % make_jobs]
+
+        self.determine_b2_options(spec, b2_options)
+
+        b2('install', 'threading=single', *b2_options)
+        b2('install', 'threading=multi', *b2_options)

--- a/var/spack/packages/boost/package.py
+++ b/var/spack/packages/boost/package.py
@@ -43,6 +43,7 @@ class Boost(Package):
     version('1.34.1', '2d938467e8a448a2c9763e0a9f8ca7e5')
     version('1.34.0', 'ed5b9291ffad776f8757a916e1726ad0')
 
+    variant('debug', default=False, description='Switch to the debug version of Boost')
     variant('python', default=False, description='Activate the component Boost.Python')
     variant('mpi', default=False, description='Activate the component Boost.MPI')
     variant('compression', default=True, description='Activate the compression Boost.iostreams')


### PR DESCRIPTION
I added variants for libraries that have external dependencies.
  - mpi to activate Boost.MPI and graph_parallel (default: False)
  - python for Boost.Python and mpi_python if mpi is activated (default: False)
  - compression for the `zlib` and `bzip2` compression in Boost.Iostream (default: True)

I changed the default compilation options to build the static and shared libraries in single and multi-threaded version. With the tagged layout they are disambiguated by addition of the `-mt` suffix.